### PR TITLE
Specify version of chromedriver package in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ extras_require = {
         'robotframework-selenium2library',
         'robotframework-debuglibrary',
         'robotframework-selenium2screenshots',
-        'chromedriver',
+        'chromedriver==2.32.0',
         'webtest',
         'mock'
     ]


### PR DESCRIPTION
Default chromedriver version is equal to 2.21, which couldn't be
installed by setuptools <= 29.0.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openprocurement/openprocurement.auction/66)
<!-- Reviewable:end -->
