### PR TITLE
Fix with parameters passing in 'get_mapping' func

### DIFF
--- a/openprocurement/auction/utils.py
+++ b/openprocurement/auction/utils.py
@@ -318,7 +318,7 @@ def create_mapping(config, auction_id, auction_url):
 
 @retry(stop_max_attempt_number=3)
 def get_mapping(config, auction_id, master=False):
-    return get_database(config).get(auction_id)
+    return get_database(config, master=master).get(auction_id)
 
 
 @retry(stop_max_attempt_number=3)


### PR DESCRIPTION
Там треба поправити. Але якщо зробити це так, як я зробив, то в модулі **auctions_server.py** функція ```auctions_proxy``` змінить свою поведінку. В ній викликається викликається get з Мемоайзера:
```
    proxy_path = auctions_server.proxy_mappings.get(
        str(auction_doc_id),
        get_mapping,
        (auctions_server.config['REDIS'], str(auction_doc_id), False), max_age=60
    )
```
і відповідно get_mapping тепер викличеться із параметром ```master=False``` і цей False передасться в ```get_database(config, master=master).get(auction_id)```. Якщо по логіці треба, щоб get_database викликався із master=True, то треба додатково змінити у функції ```auctions_proxy``` параметр ```master``` з яким викликається Мемоайзер з **False** на **True**.